### PR TITLE
gulp-rename shouldn't tamper file.path too much

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,8 +11,7 @@ module.exports = function (obj) {
 		}
 
 		// helper variables
-		var relativePath = path.relative(file.cwd, file.path),
-			dir = path.dirname(relativePath),
+		var dir = path.dirname(file.path),
 			firstname = file.path.substr(file.path.indexOf(".", 1)),
 			ext = file.path.substr(file.path.lastIndexOf(".")),
 			base = path.basename(file.path, ext),


### PR DESCRIPTION
gulp-rename was converting absolute path of file.path to relative. It shouldn't do this, and should only rename as it was meant to do.
