### PR TITLE
fix(object parameters): accept empty string for values

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,11 +31,11 @@ module.exports = function (obj) {
 
 		} else if (type === "object" && obj !== undefined && obj !== null) {
 
-			var dirname = obj.dirname || parsedPath.dirname,
+			var dirname = 'dirname' in obj ? obj.dirname : parsedPath.dirname,
 				prefix = obj.prefix || "",
 				suffix = obj.suffix || "",
-				basename = obj.basename || parsedPath.basename,
-				extname = obj.extname || parsedPath.extname;
+				basename = 'basename' in obj ? obj.basename : parsedPath.basename,
+				extname = 'extname' in obj ? obj.extname : parsedPath.extname;
 
 			path = Path.join(dirname, prefix + basename + suffix + extname);
 

--- a/test/rename.spec.js
+++ b/test/rename.spec.js
@@ -45,6 +45,20 @@ describe("gulp-rename", function () {
 				var expectedPath = "test/elsewhere/hello.txt";
 				helper(srcPattern, obj, expectedPath, done);
 			});
+			it("removes dirname with './'", function (done) {
+				var obj = {
+					dirname: "./",
+				};
+				var expectedPath = "test/hello.txt";
+				helper(srcPattern, obj, expectedPath, done);
+			});
+			it("removes dirname with empty string", function (done) {
+				var obj = {
+					dirname: "",
+				};
+				var expectedPath = "test/hello.txt";
+				helper(srcPattern, obj, expectedPath, done);
+			});
 		});
 
 		context("with prefix value", function () {
@@ -65,6 +79,14 @@ describe("gulp-rename", function () {
 				var expectedPath = "test/fixtures/aloha.txt";
 				helper(srcPattern, obj, expectedPath, done);
 			});
+			it("removes basename with empty string (for consistency)", function (done) {
+				var obj = {
+					prefix: "aloha",
+					basename: "",
+				};
+				var expectedPath = "test/fixtures/aloha.txt";
+				helper(srcPattern, obj, expectedPath, done);
+			});
 		});
 
 		context("with suffix value", function () {
@@ -78,11 +100,18 @@ describe("gulp-rename", function () {
 		});
 
 		context("with extname value", function () {
-			it("replace extname with value", function (done) {
+			it("replaces extname with value", function (done) {
 				var obj = {
 					extname: ".md",
 				};
 				var expectedPath = "test/fixtures/hello.md";
+				helper(srcPattern, obj, expectedPath, done);
+			});
+			it("removes extname with empty string", function (done) {
+				var obj = {
+					extname: "",
+				};
+				var expectedPath = "test/fixtures/hello";
 				helper(srcPattern, obj, expectedPath, done);
 			});
 		});


### PR DESCRIPTION
Enable stripping of extension using object parameters.
Empty string was being ignored.
Enable stripping of dirname and basename (for consistency) as well.
