### PR TITLE
Pass file object rename function

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,0 +1,4 @@
+1.2.1 / 2014-03-24
+==================
+
+ * pass file stream like second parameter to path function

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ gulp.src("./src/main/text/hello.txt")
 
 // rename via function
 gulp.src("./src/**/hello.txt")
-	.pipe(rename(function (path) {
+	.pipe(rename(function (path, file) {
 		path.dirname += "/ciao";
 		path.basename += "-goodbye";
 		path.extname = ".md"

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function gulpRename(obj) {
 
 		} else if (type === "function") {
 
-			var result = obj(parsedPath) || parsedPath;
+			var result = obj(parsedPath, file) || parsedPath;
 			path = Path.join(result.dirname, result.basename + result.extname);
 
 		} else if (type === "object" && obj !== undefined && obj !== null) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-rename",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Rename files",
   "keywords": [
     "gulpplugin"


### PR DESCRIPTION
For some particular situations I've needed that work watching the file stream. For instance when the src parameter is an array.

```js

gulp
  .src(['/scripts/main.js', 'styles/main.styl'])
  .rename(function(path, file){
    // work like always but now file stream is here
  });
```

Best!