### PR TITLE
extract rename as a standalone lib

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,58 +1,27 @@
 var Stream = require("stream"),
-	Path = require("path");
+	Path = require("path"),
+	rename = require("rename");
 
 function gulpRename(obj) {
 	"use strict";
 
-  var stream = new Stream.Transform({objectMode: true});
+	var stream = new Stream.Transform({objectMode: true});
 
-	function parsePath(path) {
-		var extname = Path.extname(path);
-		return {
-			dirname: Path.dirname(path),
-			basename: Path.basename(path, extname),
-			extname: extname
-		};
-	}
-
-	stream._transform = function(file, unused, callback) {
-
-		var parsedPath = parsePath(file.relative);
+	stream._transform = function (file, unused, callback) {
 		var path;
-
-		var type = typeof obj;
-
-		if (type === "string" && obj !== "") {
-
-			path = obj;
-
-		} else if (type === "function") {
-
-			var result = obj(parsedPath) || parsedPath;
-			path = Path.join(result.dirname, result.basename + result.extname);
-
-		} else if (type === "object" && obj !== undefined && obj !== null) {
-
-			var dirname = 'dirname' in obj ? obj.dirname : parsedPath.dirname,
-				prefix = obj.prefix || "",
-				suffix = obj.suffix || "",
-				basename = 'basename' in obj ? obj.basename : parsedPath.basename,
-				extname = 'extname' in obj ? obj.extname : parsedPath.extname;
-
-			path = Path.join(dirname, prefix + basename + suffix + extname);
-
-		} else {
-			callback(new Error("Unsupported renaming parameter type supplied"), undefined);
-			return;
+		try {
+			path = rename(file.relative, obj);
+		} catch (e) {
+			return callback(e);
 		}
 
 		file.path = Path.join(file.base, path);
 
 		callback(null, file);
-	}
+	};
 
 	return stream;
-};
+}
 
 module.exports = gulpRename;
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   "scripts": {
     "test": "mocha test/*.spec.js"
   },
+  "dependencies": {
+    "rename": "~0.2.0"
+  },
   "devDependencies": {
     "map-stream": ">=0.0.4",
     "mocha": ">=1.15.0",


### PR DESCRIPTION
I think rename can be used by other lib other than gulp.

You can merge this PR if you like, I will add you to rename repo as a maintainer.