### PR TITLE
Add file reference to path object argument in rename function

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ gulp.src("./src/main/text/hello.txt")
 // rename via function
 gulp.src("./src/**/hello.txt")
 	.pipe(rename(function (path) {
+		// path.file exists for reference
 		path.dirname += "/ciao";
 		path.basename += "-goodbye";
 		path.extname = ".md"
@@ -45,6 +46,7 @@ gulp.src("./src/main/text/hello.txt", { base: process.cwd() })
   * KNOWN ISSUE: The base set when using brace expansion may not be what you expect (See wearefractal/glob2base#1). Use the `base` option described above.
 * `basename` is the filename without the extension like path.basename(filename, path.extname(filename)).
 * `extname` is the file extension including the '.' like path.extname(filename).
+* `file` is the file object, included for reference.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -6,18 +6,21 @@ function gulpRename(obj) {
 
   var stream = new Stream.Transform({objectMode: true});
 
-	function parsePath(path) {
+	function parsePath(file) {
+		var path = file.relative;
 		var extname = Path.extname(path);
+		
 		return {
 			dirname: Path.dirname(path),
 			basename: Path.basename(path, extname),
-			extname: extname
+			extname: extname,
+			file: file
 		};
 	}
 
 	stream._transform = function(file, unused, callback) {
 
-		var parsedPath = parsePath(file.relative);
+		var parsedPath = parsePath(file);
 		var path;
 
 		var type = typeof obj;

--- a/test/rename.spec.js
+++ b/test/rename.spec.js
@@ -150,6 +150,14 @@ describe("gulp-rename", function () {
 			helper(srcPattern, obj, expectedPath, done);
 		});
 
+		it("receives object with file", function (done) {
+			var obj = function (path) {
+				path.file.should.be.an.Object
+			};
+			var expectedPath = "test/fixtures/hello.txt";
+			helper(srcPattern, obj, expectedPath, done);
+		});
+
 		it("can return a whole new object", function (done) {
 			var obj = function (/*path*/) {
 				return {


### PR DESCRIPTION
__Why__
Having a reference to the original file can aid in determining what each particular file in a glob should be renamed to. For example, renaming a file based on a hash of its contents for cache busting.

__What I did__
I added a `file` property to the `path` object passed into the rename function. This property is not used to alter the file in any way -- it is only there for reference.