### PR TITLE
Don't check what's returned from passed function

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,8 +28,8 @@ function gulpRename(obj) {
 
 		} else if (type === "function") {
 
-			var result = obj(parsedPath) || parsedPath;
-			path = Path.join(result.dirname, result.basename + result.extname);
+			obj(parsedPath);
+			path = Path.join(parsedPath.dirname, parsedPath.basename + parsedPath.extname);
 
 		} else if (type === "object" && obj !== undefined && obj !== null) {
 

--- a/test/rename.spec.js
+++ b/test/rename.spec.js
@@ -150,7 +150,7 @@ describe("gulp-rename", function () {
 			helper(srcPattern, obj, expectedPath, done);
 		});
 
-		it("can return a whole new object", function (done) {
+		it("ignores the return value", function (done) {
 			var obj = function (/*path*/) {
 				return {
 					dirname: "elsewhere",
@@ -158,7 +158,16 @@ describe("gulp-rename", function () {
 					extname: ".md"
 				};
 			};
-			var expectedPath = "test/elsewhere/aloha.md";
+			var expectedPath = "test/fixtures/hello.txt";
+			helper(srcPattern, obj, expectedPath, done);
+		});
+
+		it("receives object with extname even if a different value is returned", function (done) {
+			var obj = function (path) {
+				path.extname.should.equal(".txt");
+				return path.extname = ".md";
+			};
+			var expectedPath = "test/fixtures/hello.md";
 			helper(srcPattern, obj, expectedPath, done);
 		});
 	});


### PR DESCRIPTION
1. By default, CoffeeScript will return the last line in a function. If you had the following:
    ```coffeescript
    .pipe($.rename (path) =>
            path.extname = '.html'
    )
    ```

   Then your gulp task would fail with `TypeError: Arguments to path.join must be strings`, unless you end the function with `return path` / `return` / `return` a falsy value.
   
2. It's kinda ambiguous / confusing. I can't think of a use case where you'd edit the original but return something else (since the original will overridden with what you return anyway).

---

I didn't check the tests, I just made this change on github.com. If they fail, I'll come back to them later.