### PR TITLE
Fix the rename with function example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ gulp.src("./src/**/hello.txt")
 	.pipe(rename(function (path) {
 		path.dirname += "/ciao";
 		path.basename += "-goodbye";
-		path.extname = ".md"
+		path.extname = ".md";
+		return path;
 	}))
 	.pipe(gulp.dest("./dist")); // ./dist/main/text/ciao/hello-goodbye.md
 


### PR DESCRIPTION
The readme example of call with function seems to be missing a return statement, so I've added it in.