### PR TITLE
Travis: Removed Node 0.9, added 0.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - 0.9
   - 0.10
+  - 0.11


### PR DESCRIPTION
Travis [doesn't support 0.9](http://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Provided-Node.js-Versions). 

0.9 had been removed (https://github.com/hparra/gulp-rename/commit/30d9519e4b7114cdb01e6d8c28099b9b9fef7f4b) but re-added (https://github.com/hparra/gulp-rename/commit/88a9730a842f754deb2f837fd42bf66d53fa5bdc) (but someone did [comment](https://github.com/hparra/gulp-rename/commit/88a9730a842f754deb2f837fd42bf66d53fa5bdc#commitcomment-5136899) to point out that it was wrong). 

This is why Travis reported a build error for #24 as well.