### PR TITLE
Add source map support

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var Stream = require("stream"),
 function gulpRename(obj) {
 	"use strict";
 
-  var stream = new Stream.Transform({objectMode: true});
+	var stream = new Stream.Transform({objectMode: true});
 
 	function parsePath(path) {
 		var extname = Path.extname(path);
@@ -49,9 +49,9 @@ function gulpRename(obj) {
 		file.path = Path.join(file.base, path);
 
 		// Rename sourcemap if present
-    if (file.sourceMap) {
-      file.sourceMap.file = file.relative;
-    }
+		if (file.sourceMap) {
+			file.sourceMap.file = file.relative;
+		}
 
 		callback(null, file);
 	}

--- a/index.js
+++ b/index.js
@@ -48,6 +48,11 @@ function gulpRename(obj) {
 
 		file.path = Path.join(file.base, path);
 
+		// Rename sourcemap if present
+    if (file.sourceMap) {
+      file.sourceMap.file = file.relative;
+    }
+
 		callback(null, file);
 	}
 
@@ -55,4 +60,3 @@ function gulpRename(obj) {
 };
 
 module.exports = gulpRename;
-

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "test": "mocha test/*.spec.js"
   },
   "devDependencies": {
+    "gulp-sourcemaps": "^1.5.0",
+    "gulp-util": "^3.0.4",
     "map-stream": ">=0.0.4",
     "mocha": ">=1.15.0",
     "should": ">=2.1.0",

--- a/test/rename-sourcemap.spec.js
+++ b/test/rename-sourcemap.spec.js
@@ -8,31 +8,31 @@ require("should");
 
 describe("gulp-rename", function () {
 
-  context("when file has source map", function () {
+	context("when file has source map", function () {
 
-    it ("updates source map file to match relative path of renamed file", function (done) {
+		it ("updates source map file to match relative path of renamed file", function (done) {
 
-      var init = sourceMaps.init();
-      var stream = rename({ prefix: "test-" });
+			var init = sourceMaps.init();
+			var stream = rename({ prefix: "test-" });
 
-      init.pipe(stream);
+			init.pipe(stream);
 
-      stream.on("data", function (file) {
-        file.sourceMap.file.should.equal("test-fixture.css");
-        file.sourceMap.file.should.equal(file.relative);
-        done();
-      });
+			stream.on("data", function (file) {
+				file.sourceMap.file.should.equal("test-fixture.css");
+				file.sourceMap.file.should.equal(file.relative);
+				done();
+			});
 
-      init.write(new gutil.File({
-        base: "fixtures",
-        path: "fixtures/fixture.css",
-        contents: new Buffer("")
-      }));
+			init.write(new gutil.File({
+				base: "fixtures",
+				path: "fixtures/fixture.css",
+				contents: new Buffer("")
+			}));
 
-      init.end();
+			init.end();
 
-    });
+		});
 
-  });
+	});
 
 });

--- a/test/rename-sourcemap.spec.js
+++ b/test/rename-sourcemap.spec.js
@@ -13,12 +13,12 @@ describe("gulp-rename", function () {
 		it ("updates source map file to match relative path of renamed file", function (done) {
 
 			var init = sourceMaps.init();
-			var stream = rename({ prefix: "test-" });
-
-			init.pipe(stream);
+			var stream = init
+				.pipe(rename({ prefix: "test-" }))
+				.pipe(rename({ prefix: "test-" }));
 
 			stream.on("data", function (file) {
-				file.sourceMap.file.should.equal("test-fixture.css");
+				file.sourceMap.file.should.equal("test-test-fixture.css");
 				file.sourceMap.file.should.equal(file.relative);
 				done();
 			});

--- a/test/rename-sourcemap.spec.js
+++ b/test/rename-sourcemap.spec.js
@@ -1,0 +1,38 @@
+/* global context, describe, it */
+"use strict";
+
+var rename = require("../index");
+var gutil = require("gulp-util");
+var sourceMaps = require("gulp-sourcemaps");
+require("should");
+
+describe("gulp-rename", function () {
+
+  context("when file has source map", function () {
+
+    it ("updates source map file to match relative path of renamed file", function (done) {
+
+      var init = sourceMaps.init();
+      var stream = rename({ prefix: "test-" });
+
+      init.pipe(stream);
+
+      stream.on("data", function (file) {
+        file.sourceMap.file.should.equal("test-fixture.css");
+        file.sourceMap.file.should.equal(file.relative);
+        done();
+      });
+
+      init.write(new gutil.File({
+        base: "fixtures",
+        path: "fixtures/fixture.css",
+        contents: new Buffer("")
+      }));
+
+      init.end();
+
+    });
+
+  });
+
+});


### PR DESCRIPTION
Fixes #37 

In order to work with gulp-sourcemaps, if `sourceMap` is present, its `file` attribute should be set to `file.relative` after file is renamed.

