### PR TITLE
Pass file to renaming function

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ function gulpRename(obj) {
 
     } else if (type === 'function') {
 
-      obj(parsedPath);
+      obj(parsedPath, file);
       path = Path.join(parsedPath.dirname, parsedPath.basename + parsedPath.extname);
 
     } else if (type === 'object' && obj !== undefined && obj !== null) {


### PR DESCRIPTION
Rename function could decide the new name based on the old name only.

By passing it also the file object, it can take into account data
extracted earlier in the pipeline (e.g. file.frontMatter, file.data,
...) or raw file contents. Example of renaming a file to a slug of the
title set in YAML front matter:

    gulp.task('generate_html', function() {
        return gulp.src('articles/*.md')
            .pipe(frontMatter({
                property: 'frontMatter',
                remove: true
            }))
            .pipe(rename(function(path, file) {
                path.basename = slug(file.frontMatter.title).toLowerCase();
            }))
            .pipe(markdown2html())
            .pipe(gulp.dest('html/'));
    }