### PR TITLE
Clone the original file prior to renaming

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,8 +16,10 @@ function gulpRename(obj) {
     };
   }
 
-  stream._transform = function (file, unused, callback) {
+  stream._transform = function (originalFile, unused, callback) {
 
+
+    var file = originalFile.clone({contents: false});
     var parsedPath = parsePath(file.relative);
     var path;
 


### PR DESCRIPTION
The file object is being mutated it should be cloned prior to the rename operation. Otherwise if there are other pipelines modifying the same file the clone could be applied twice.

This makes the results of the rename immutable.