### PR TITLE
Return path in rename by function example

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ gulp.src("./src/**/hello.txt")
   .pipe(rename(function (path) {
     path.dirname += "/ciao";
     path.basename += "-goodbye";
-    path.extname = ".md"
+    path.extname = ".md";
+    return path;
   }))
   .pipe(gulp.dest("./dist")); // ./dist/main/text/ciao/hello-goodbye.md
 


### PR DESCRIPTION
At least the only way I got renaming by function to work is by adding `return path;` to the function.