### PR TITLE
Allow Relative Paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ gulp.src("./src/**/hello.txt")
   }))
   .pipe(gulp.dest("./dist")); // ./dist/main/text/ciao/hello-goodbye.md
 
+// rename with path relative to top-level glob, via function
+gulp.src("./src/**/hello.txt")
+  .pipe(rename(function (path) {
+    path.dirname += "/ciao";
+    path.basename += "-goodbye";
+    path.extname = ".md";
+    path.relative = true;
+    return path;
+  }))
+  .pipe(gulp.dest("./dist")); // ./dist/main/text/ciao/hello-goodbye.md
+
 // rename via hash
 gulp.src("./src/main/text/hello.txt", { base: process.cwd() })
   .pipe(rename({

--- a/index.js
+++ b/index.js
@@ -51,7 +51,11 @@ function gulpRename(obj) {
 
     }
 
-    file.path = Path.join(file.base, path);
+    if (parsedPath.relative === true){
+      file.path = path;
+    } else {
+      file.path = Path.join(file.base, path);
+    }
 
     // Rename sourcemap if present
     if (file.sourceMap) {

--- a/test/path-parsing.spec.js
+++ b/test/path-parsing.spec.js
@@ -34,6 +34,16 @@ describe('gulp-rename path parsing', function () {
         helper(srcPattern, obj, null, done);
       });
     };
+    
+    context('when src pattern matches a directory with **, but relative flag is supplied', function () {
+      var srcPattern = 'test/**/*.min.txt'
+      it('dirname is path from directory glob to file, dropping path prior to glob', function (done) {
+        var obj = function (path) {
+          path.dirname.should.match(/fixtures[0-9]?$/);
+        };
+        helper(srcPattern, obj, null, done);
+      });
+    });
 
     context('when src pattern matches a directory with *', function () {
       dirnameHelper('test/*/*.min.txt');

--- a/test/rename.spec.js
+++ b/test/rename.spec.js
@@ -40,6 +40,16 @@ describe('gulp-rename', function () {
       });
     });
 
+    context('with relative flag', function () {
+      it('removes the path before the glob', function (done) {
+        var obj = {
+          relative: true
+        };
+        var expectedPath = 'fixtures/hello.txt';
+        helper(srcPattern, obj, expectedPath, done);
+      });
+    });
+
     context('with dirname value', function () {
       it('replaces dirname with value', function (done) {
         var obj = {
@@ -171,6 +181,15 @@ describe('gulp-rename', function () {
         path.extname = '.md';
       };
       var expectedPath = 'test/fixtures/hello.md';
+      helper(srcPattern, obj, expectedPath, done);
+    });
+    
+    it('removes the path before the glob with relative flag === true', function (done) {
+      var obj = function (path) {
+        path.dirname.should.equal('fixtures');
+        path.relative = true;
+      };
+      var expectedPath = 'fixtures/hello.txt';
       helper(srcPattern, obj, expectedPath, done);
     });
   });


### PR DESCRIPTION
This pull request adds an option to pass `{ relative:true }` to the path object (either through the object or function methods) in order to keep the path relative to the file glob. Normally this bit is removed and renamed with `gulp.dest()` but when renaming and concatenating compiled JST template files, the full absolute path name is passed making the name of the template non-portable if developers set up their build environments in different locations. 

This small change allows users to pass a flag that eliminates the step of re-applying the absolute path and allows the path to remain relative.