### PR TITLE
Fix confusing example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ gulp.src("./src/**/hello.txt")
     path.dirname += "/ciao";
     path.basename += "-goodbye";
     path.extname = ".md";
-    return path;
   }))
   .pipe(gulp.dest("./dist")); // ./dist/main/text/ciao/hello-goodbye.md
 


### PR DESCRIPTION
Remove useless and confusing `return` statement in "function argument" example.
cf. 'ignores the return value': `test/rename.spec.js:156`:
  https://github.com/hparra/gulp-rename/blob/master/test/rename.spec.js#L156