### PR TITLE
Add multiExt option

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,12 +3,14 @@
 var Stream = require('stream');
 var Path = require('path');
 
-function gulpRename(obj) {
+function gulpRename(obj, options) {
+
+  options = options || {};
 
   var stream = new Stream.Transform({objectMode: true});
 
   function parsePath(path) {
-    var extname = Path.extname(path);
+    var extname = options.multiExt ? Path.basename(path).slice(Path.basename(path).indexOf('.')) : Path.extname(path);
     return {
       dirname: Path.dirname(path),
       basename: Path.basename(path, extname),

--- a/test/path-parsing.spec.js
+++ b/test/path-parsing.spec.js
@@ -102,4 +102,15 @@ describe('gulp-rename path parsing', function () {
       helper(srcPattern, obj, null, done);
     });
   });
+
+  describe('multiExt option', function () {
+    it('includes multiple extensions in extname', function (done) {
+      var srcPattern = 'test/fixtures/hello.min.txt';
+      var obj = function (path) {
+        path.extname.should.equal('.min.txt');
+        path.basename.should.equal('hello');
+      };
+      helper(srcPattern, obj, null, done, { multiExt: true });
+    });
+  });
 });

--- a/test/spec-helper.js
+++ b/test/spec-helper.js
@@ -7,10 +7,10 @@ var Path = require('path'),
   gulp = require('gulp'),
   rename = require('../');
 
-global.helper = function (srcArgs, obj, expectedPath, done) {
+global.helper = function (srcArgs, obj, expectedPath, done, options) {
   var srcPattern = srcArgs.pattern || srcArgs;
   var srcOptions = srcArgs.options || {};
-  var stream = gulp.src(srcPattern, srcOptions).pipe(rename(obj));
+  var stream = gulp.src(srcPattern, srcOptions).pipe(rename(obj, options));
   var count = 0;
   stream.on('error', done);
   stream.on('data', function () {


### PR DESCRIPTION
Allows parsing a path with multiple extensions.

Closes #16.