### PR TITLE
Use returned object in 'function' mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,26 @@ gulp.src("./src/main/text/hello.txt")
   .pipe(rename("main/text/ciao/goodbye.md"))
   .pipe(gulp.dest("./dist")); // ./dist/main/text/ciao/goodbye.md
 
-// rename via function
+// rename via function's parameter
 gulp.src("./src/**/hello.txt")
   .pipe(rename(function (path) {
+    // Updates the configurations in-place.
     path.dirname += "/ciao";
     path.basename += "-goodbye";
     path.extname = ".md";
+  }))
+  .pipe(gulp.dest("./dist")); // ./dist/main/text/ciao/hello-goodbye.md
+
+// rename via function's return value
+gulp.src("./src/**/hello.txt")
+  .pipe(rename(function (path) {
+    // Upon returning a new object, all the configurations in `path` will be discarded.
+    // Ensure to clone or re-use `path` if you want any configurations to persist.
+    return {
+      dirname: path.dirname + "/ciao",
+      basename: path.basename + "-goodbye",
+      extname: ".md"
+    };
   }))
   .pipe(gulp.dest("./dist")); // ./dist/main/text/ciao/hello-goodbye.md
 
@@ -50,6 +64,7 @@ gulp.src("./src/main/text/hello.txt", { base: process.cwd() })
 * `basename` is the filename without the extension like path.basename(filename, path.extname(filename)).
 * `extname` is the file extension including the '.' like path.extname(filename).
 * when using a function, a second `file` argument is provided with the whole context and original file value
+* when using a function, if no `Object` is returned then the passed parameter object (along with any modifications) is re-used
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -14,26 +14,25 @@ gulp-rename provides simple file renaming methods.
 ```javascript
 var rename = require("gulp-rename");
 
-// rename via string
+// rename to a fixed value
 gulp.src("./src/main/text/hello.txt")
   .pipe(rename("main/text/ciao/goodbye.md"))
   .pipe(gulp.dest("./dist")); // ./dist/main/text/ciao/goodbye.md
 
-// rename via function's parameter
+// rename via mutating function
 gulp.src("./src/**/hello.txt")
   .pipe(rename(function (path) {
-    // Updates the configurations in-place.
+    // Updates the object in-place
     path.dirname += "/ciao";
     path.basename += "-goodbye";
     path.extname = ".md";
   }))
   .pipe(gulp.dest("./dist")); // ./dist/main/text/ciao/hello-goodbye.md
 
-// rename via function's return value
+// rename via a map function
 gulp.src("./src/**/hello.txt")
   .pipe(rename(function (path) {
-    // Upon returning a new object, all the configurations in `path` will be discarded.
-    // Ensure to clone or re-use `path` if you want any configurations to persist.
+    // Returns a completely new object, make sure you return all keys needed!
     return {
       dirname: path.dirname + "/ciao",
       basename: path.basename + "-goodbye",
@@ -42,7 +41,7 @@ gulp.src("./src/**/hello.txt")
   }))
   .pipe(gulp.dest("./dist")); // ./dist/main/text/ciao/hello-goodbye.md
 
-// rename via hash
+// rename via a fixed object
 gulp.src("./src/main/text/hello.txt", { base: process.cwd() })
   .pipe(rename({
     dirname: "main/text/ciao",

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ function gulpRename(obj, options) {
     } else if (type === 'function') {
 
       let newParsedPath = obj(parsedPath, file);
-      if (typeof newParsedPath === 'object') {
+      if (typeof newParsedPath === 'object' && newParsedPath !== null) {
         parsedPath = newParsedPath;
       }
       

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ function gulpRename(obj, options) {
     } else if (type === 'function') {
 
       let newParsedPath = obj(parsedPath, file);
-      if (typeof newParsedPath === "object") {
+      if (typeof newParsedPath === 'object') {
         parsedPath = newParsedPath;
       }
       

--- a/index.js
+++ b/index.js
@@ -33,7 +33,11 @@ function gulpRename(obj, options) {
 
     } else if (type === 'function') {
 
-      obj(parsedPath, file);
+      let newParsedPath = obj(parsedPath, file);
+      if (typeof newParsedPath === "object") {
+        parsedPath = newParsedPath;
+      }
+      
       path = Path.join(parsedPath.dirname, parsedPath.basename + parsedPath.extname);
 
     } else if (type === 'object' && obj !== undefined && obj !== null) {

--- a/test/rename.spec.js
+++ b/test/rename.spec.js
@@ -153,15 +153,15 @@ describe('gulp-rename', function () {
       helper(srcPattern, obj, expectedPath, done);
     });
 
-    it('ignores the return value', function (done) {
-      var obj = function (/*path*/) {
+    it('receives object from return value', function (done) {
+      var obj = function (path) {
         return {
-          dirname: 'elsewhere',
-          basename: 'aloha',
+          dirname: path.dirname,
+          basename: path.basename,
           extname: '.md'
         };
       };
-      var expectedPath = 'test/fixtures/hello.txt';
+      var expectedPath = 'test/fixtures/hello.md';
       helper(srcPattern, obj, expectedPath, done);
     });
 

--- a/test/rename.spec.js
+++ b/test/rename.spec.js
@@ -165,6 +165,16 @@ describe('gulp-rename', function () {
       helper(srcPattern, obj, expectedPath, done);
     });
 
+    it('ignores null return value but uses passed object', function (done) {
+      var obj = function (path) {
+        path.extname.should.equal('.txt');
+        path.extname = '.md';
+        return null;
+      };
+      var expectedPath = 'test/fixtures/hello.md';
+      helper(srcPattern, obj, expectedPath, done);
+    });
+
     it('receives object with extname even if a different value is returned', function (done) {
       var obj = function (path) {
         path.extname.should.equal('.txt');


### PR DESCRIPTION
When a function is provided as parameter, the return value, if it exists, is used as the new `parsedPath`. Otherwise, as earlier, the passed parameter is used assuming it has been modified accordingly.

Fixes #85 