### PR TITLE
Upgrade packages to address the fs.Stats constructor warning from vinyl-fs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var Stream = require('stream');
-var Path = require('path');
+const Stream = require('stream');
+const Path = require('path');
 
 function gulpRename(obj, options) {
   options = options || {};
@@ -15,11 +15,11 @@ function gulpRename(obj, options) {
     return {
       dirname: Path.dirname(path),
       basename: Path.basename(path, extname),
-      extname: extname
+      extname: extname,
     };
   }
 
-  stream._transform = function(originalFile, unused, callback) {
+  stream._transform = function (originalFile, unused, callback) {
     var file = originalFile.clone({ contents: false });
     var parsedPath = parsePath(file.relative);
     var path;
@@ -36,7 +36,7 @@ function gulpRename(obj, options) {
 
       path = Path.join(
         parsedPath.dirname,
-        parsedPath.basename + parsedPath.extname
+        parsedPath.basename + parsedPath.extname,
       );
     } else if (type === 'object' && obj !== undefined && obj !== null) {
       var dirname = 'dirname' in obj ? obj.dirname : parsedPath.dirname,
@@ -49,7 +49,7 @@ function gulpRename(obj, options) {
     } else {
       callback(
         new Error('Unsupported renaming parameter type supplied'),
-        undefined
+        undefined,
       );
       return;
     }

--- a/package.json
+++ b/package.json
@@ -25,13 +25,15 @@
     "test": "mocha"
   },
   "devDependencies": {
-    "gulp": "^4.0.2",
+    "gulp": "^5.0.1",
     "gulp-sourcemaps": "^2.6.5",
     "map-stream": "^0.0.7",
-    "mocha": "^6.0.0",
-    "prettier": "^1.19.1",
+    "mocha": "^11.6.0",
+    "postcss": "^8.5.6",
+    "prettier": "3.5.3",
     "should": "^13.2.3",
-    "vinyl": "^2.0.0"
+    "teex": "^1.0.1",
+    "vinyl": "^3.0.1"
   },
   "engines": {
     "node": ">=4"

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
   "name": "gulp-rename",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Rename files",
   "keywords": [
     "gulpplugin"
   ],
-  "homepage": "https://github.com/hparra/gulp-rename",
-  "bugs": "https://github.com/hparra/gulp-rename/issues",
+  "homepage": "https://github.com/veritashealth/gulp-rename",
+  "bugs": "https://github.com/veritashealth/gulp-rename/issues",
   "author": {
-    "name": "Hector Guillermo Parra Alvarez",
-    "email": "hector@hectorparra.com",
-    "url": "https://github.com/hparra"
+    "name": "Forked from Hector Guillermo Parra Alvarez",
+    "email": "dvenckus@veritashealth.com",
+    "url": "https://github.com/dvenckusvh"
   },
   "main": "./index.js",
   "files": [
@@ -18,7 +18,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/hparra/gulp-rename.git"
+    "url": "git://github.com/veritashealth/gulp-rename.git"
   },
   "scripts": {
     "pretest": "prettier --single-quote --write index.js test/**/*.js",

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
-  "name": "@veritashealth/gulp-rename",
-  "version": "2.1.0",
+  "name": "gulp-rename",
+  "version": "2.0.0",
   "description": "Rename files",
   "keywords": [
     "gulpplugin"
   ],
-  "homepage": "https://github.com/veritashealth/gulp-rename",
-  "bugs": "https://github.com/veritashealth/gulp-rename/issues",
+  "homepage": "https://github.com/hparra/gulp-rename",
+  "bugs": "https://github.com/hparra/gulp-rename/issues",
   "author": {
-    "name": "Forked from Hector Guillermo Parra Alvarez",
-    "email": "dvenckus@veritashealth.com",
-    "url": "https://github.com/dvenckusvh"
+    "name": "Hector Guillermo Parra Alvarez",
+    "email": "hector@hectorparra.com",
+    "url": "https://github.com/hparra"
   },
   "main": "./index.js",
   "files": [
@@ -18,7 +18,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/veritashealth/gulp-rename.git"
+    "url": "git://github.com/hparra/gulp-rename.git"
   },
   "scripts": {
     "pretest": "prettier --single-quote --write index.js test/**/*.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gulp-rename",
+  "name": "@veritashealth/gulp-rename",
   "version": "2.1.0",
   "description": "Rename files",
   "keywords": [

--- a/test/path-parsing.spec.js
+++ b/test/path-parsing.spec.js
@@ -4,70 +4,73 @@
 require('./spec-helper');
 var Path = require('path');
 
-describe('gulp-rename path parsing', function() {
-  describe('dirname', function() {
-    context('when src pattern contains no globs', function() {
-      it("dirname is '.'", function(done) {
+describe('gulp-rename path parsing', function () {
+  describe('dirname', function () {
+    context('when src pattern contains no globs', function () {
+      it("dirname is '.'", function (done) {
         var srcPattern = 'test/fixtures/hello.txt';
-        var obj = function(path) {
+        var obj = function (path) {
           path.dirname.should.equal('.');
         };
         helper(srcPattern, obj, null, done);
       });
     });
 
-    context('when src pattern contains filename glob', function() {
-      it("dirname is '.'", function(done) {
+    context('when src pattern contains filename glob', function () {
+      it("dirname is '.'", function (done) {
         var srcPattern = 'test/fixtures/*.min.txt';
-        var obj = function(path) {
+        var obj = function (path) {
           path.dirname.should.equal('.');
         };
         helper(srcPattern, obj, null, done);
       });
     });
 
-    var dirnameHelper = function(srcPattern) {
-      it('dirname is path from directory glob to file', function(done) {
-        var obj = function(path) {
+    var dirnameHelper = function (srcPattern) {
+      it('dirname is path from directory glob to file', function (done) {
+        var obj = function (path) {
           path.dirname.should.match(/^fixtures[0-9]?$/);
         };
         helper(srcPattern, obj, null, done);
       });
     };
 
-    context('when src pattern matches a directory with *', function() {
+    context('when src pattern matches a directory with *', function () {
       dirnameHelper('test/*/*.min.txt');
     });
 
-    context('when src pattern matches a directory with **', function() {
+    context('when src pattern matches a directory with **', function () {
       dirnameHelper('test/**/*.min.txt');
     });
 
-    context('when src pattern matches a directory with [...]', function() {
+    context('when src pattern matches a directory with [...]', function () {
       dirnameHelper('test/fixt[a-z]res/*.min.txt');
     });
 
-    context('when src pattern matches a directory with {...,...}', function() {
+    context('when src pattern matches a directory with {...,...}', function () {
       dirnameHelper('test/f{ri,ixtur}es/*.min.txt');
     });
 
     /* SKIP: glob2base does not handle brace expansion as expected. See wearefractal/glob2base#1 */
     context.skip(
       'when src pattern matches a directory with {#..#}',
-      function() {
+      function () {
         dirnameHelper('test/fixtures{0..9}/*.min.txt');
-      }
+      },
     );
 
-    context('when src pattern matches a directory with an extglob', function() {
-      dirnameHelper('test/f+(ri|ixtur)es/*.min.txt');
-    });
+    context(
+      'when src pattern matches a directory with an extglob',
+      function () {
+        dirnameHelper('test/f+(ri|ixtur)es/*.min.txt');
+      },
+    );
 
-    context('when src pattern includes `base` option', function() {
-      it('dirname is path from given directory to file', function(done) {
+    context('when src pattern includes `base` option', function () {
+      it('dirname is path from given directory to file', function (done) {
         var srcPattern = 'test/**/*.min.txt';
         var srcOptions = { base: process.cwd() };
-        var obj = function(path) {
+        var obj = function (path) {
           path.dirname.should.equal(Path.join('test', 'fixtures'));
         };
         helper({ pattern: srcPattern, options: srcOptions }, obj, null, done);
@@ -75,32 +78,32 @@ describe('gulp-rename path parsing', function() {
     });
   });
 
-  describe('basename', function() {
-    it('strips extension like Path.basename(path, ext)', function(done) {
+  describe('basename', function () {
+    it('strips extension like Path.basename(path, ext)', function (done) {
       var srcPattern = 'test/fixtures/hello.min.txt';
-      var obj = function(path) {
+      var obj = function (path) {
         path.basename.should.equal('hello.min');
         path.basename.should.equal(
-          Path.basename(srcPattern, Path.extname(srcPattern))
+          Path.basename(srcPattern, Path.extname(srcPattern)),
         );
       };
       helper(srcPattern, obj, null, done);
     });
   });
 
-  describe('extname', function() {
-    it("includes '.' like Path.extname", function(done) {
+  describe('extname', function () {
+    it("includes '.' like Path.extname", function (done) {
       var srcPattern = 'test/fixtures/hello.txt';
-      var obj = function(path) {
+      var obj = function (path) {
         path.extname.should.equal('.txt');
         path.extname.should.equal(Path.extname(srcPattern));
       };
       helper(srcPattern, obj, null, done);
     });
 
-    it('excludes multiple extensions like Path.extname', function(done) {
+    it('excludes multiple extensions like Path.extname', function (done) {
       var srcPattern = 'test/fixtures/hello.min.txt';
-      var obj = function(path) {
+      var obj = function (path) {
         path.extname.should.equal('.txt');
         path.extname.should.equal(Path.extname(srcPattern));
       };
@@ -108,10 +111,10 @@ describe('gulp-rename path parsing', function() {
     });
   });
 
-  describe('multiExt option', function() {
-    it('includes multiple extensions in extname', function(done) {
+  describe('multiExt option', function () {
+    it('includes multiple extensions in extname', function (done) {
       var srcPattern = 'test/fixtures/hello.min.txt';
-      var obj = function(path) {
+      var obj = function (path) {
         path.extname.should.equal('.min.txt');
         path.basename.should.equal('hello');
       };
@@ -119,19 +122,19 @@ describe('gulp-rename path parsing', function() {
     });
   });
 
-  describe('original file context', function() {
-    it('passed to plugin as second argument', function(done) {
+  describe('original file context', function () {
+    it('passed to plugin as second argument', function (done) {
       var srcPattern = 'test/fixtures/hello.min.txt';
-      var obj = function(path, file) {
+      var obj = function (path, file) {
         file.should.be.instanceof(Object);
         file.should.be.ok();
       };
       helper(srcPattern, obj, null, done, { multiExt: true });
     });
 
-    it('has expected properties', function(done) {
+    it('has expected properties', function (done) {
       var srcPattern = 'test/fixtures/hello.min.txt';
-      var obj = function(path, file) {
+      var obj = function (path, file) {
         file.path.should.equal(Path.resolve(srcPattern));
         file.base.should.equal(Path.dirname(Path.resolve(srcPattern)));
         file.basename.should.equal(Path.basename(srcPattern));

--- a/test/rename-sourcemap.spec.js
+++ b/test/rename-sourcemap.spec.js
@@ -5,15 +5,15 @@ var Vinyl = require('vinyl');
 var sourceMaps = require('gulp-sourcemaps');
 require('should');
 
-describe('gulp-rename', function() {
-  context('when file has source map', function() {
-    it('updates source map file to match relative path of renamed file', function(done) {
+describe('gulp-rename', function () {
+  context('when file has source map', function () {
+    it('updates source map file to match relative path of renamed file', function (done) {
       var init = sourceMaps.init();
       var stream = init
         .pipe(rename({ prefix: 'test-' }))
         .pipe(rename({ prefix: 'test-' }));
 
-      stream.on('data', function(file) {
+      stream.on('data', function (file) {
         file.sourceMap.file.should.equal('test-test-fixture.css');
         file.sourceMap.file.should.equal(file.relative);
         done();
@@ -23,8 +23,8 @@ describe('gulp-rename', function() {
         new Vinyl({
           base: 'fixtures',
           path: 'fixtures/fixture.css',
-          contents: new Buffer('')
-        })
+          contents: new Buffer(''),
+        }),
       );
 
       init.end();

--- a/test/rename.spec.js
+++ b/test/rename.spec.js
@@ -2,22 +2,23 @@
 /* global helper, helperError */
 
 require('./spec-helper');
-var rename = require('../');
-var gulp = require('gulp');
-var Path = require('path');
+const rename = require('../');
+const gulp = require('gulp');
+const Path = require('path');
+const teex = require('teex');
 
-describe('gulp-rename', function() {
-  context('with string parameter', function() {
-    context('when src pattern does not contain directory glob', function() {
-      it('sets filename to value', function(done) {
+describe('gulp-rename', function () {
+  context('with string parameter', function () {
+    context('when src pattern does not contain directory glob', function () {
+      it('sets filename to value', function (done) {
         var srcPattern = 'test/fixtures/hello.txt';
         var obj = 'hola.md';
         var expectedPath = 'test/fixtures/hola.md';
         helper(srcPattern, obj, expectedPath, done);
       });
     });
-    context('when src pattern contains directory glob', function() {
-      it('sets relative path to value', function(done) {
+    context('when src pattern contains directory glob', function () {
+      it('sets relative path to value', function (done) {
         var srcPattern = 'test/**/hello.txt';
         var obj = 'fixtures/hola.md';
         var expectedPath = 'test/fixtures/hola.md';
@@ -26,93 +27,93 @@ describe('gulp-rename', function() {
     });
   });
 
-  context('with object parameter', function() {
+  context('with object parameter', function () {
     var srcPattern;
-    beforeEach(function() {
+    beforeEach(function () {
       srcPattern = 'test/**/hello.txt';
     });
 
-    context('with empty object', function() {
-      it('has no effect', function(done) {
+    context('with empty object', function () {
+      it('has no effect', function (done) {
         var obj = {};
         var expectedPath = 'test/fixtures/hello.txt';
         helper(srcPattern, obj, expectedPath, done);
       });
     });
 
-    context('with dirname value', function() {
-      it('replaces dirname with value', function(done) {
+    context('with dirname value', function () {
+      it('replaces dirname with value', function (done) {
         var obj = {
-          dirname: 'elsewhere'
+          dirname: 'elsewhere',
         };
         var expectedPath = 'test/elsewhere/hello.txt';
         helper(srcPattern, obj, expectedPath, done);
       });
-      it("removes dirname with './'", function(done) {
+      it("removes dirname with './'", function (done) {
         var obj = {
-          dirname: './'
+          dirname: './',
         };
         var expectedPath = 'test/hello.txt';
         helper(srcPattern, obj, expectedPath, done);
       });
-      it('removes dirname with empty string', function(done) {
+      it('removes dirname with empty string', function (done) {
         var obj = {
-          dirname: ''
+          dirname: '',
         };
         var expectedPath = 'test/hello.txt';
         helper(srcPattern, obj, expectedPath, done);
       });
     });
 
-    context('with prefix value', function() {
-      it('prepends value to basename', function(done) {
+    context('with prefix value', function () {
+      it('prepends value to basename', function (done) {
         var obj = {
-          prefix: 'bonjour-'
+          prefix: 'bonjour-',
         };
         var expectedPath = 'test/fixtures/bonjour-hello.txt';
         helper(srcPattern, obj, expectedPath, done);
       });
     });
 
-    context('with basename value', function() {
-      it('replaces basename with value', function(done) {
+    context('with basename value', function () {
+      it('replaces basename with value', function (done) {
         var obj = {
-          basename: 'aloha'
+          basename: 'aloha',
         };
         var expectedPath = 'test/fixtures/aloha.txt';
         helper(srcPattern, obj, expectedPath, done);
       });
-      it('removes basename with empty string (for consistency)', function(done) {
+      it('removes basename with empty string (for consistency)', function (done) {
         var obj = {
           prefix: 'aloha',
-          basename: ''
+          basename: '',
         };
         var expectedPath = 'test/fixtures/aloha.txt';
         helper(srcPattern, obj, expectedPath, done);
       });
     });
 
-    context('with suffix value', function() {
-      it('appends value to basename', function(done) {
+    context('with suffix value', function () {
+      it('appends value to basename', function (done) {
         var obj = {
-          suffix: '-hola'
+          suffix: '-hola',
         };
         var expectedPath = 'test/fixtures/hello-hola.txt';
         helper(srcPattern, obj, expectedPath, done);
       });
     });
 
-    context('with extname value', function() {
-      it('replaces extname with value', function(done) {
+    context('with extname value', function () {
+      it('replaces extname with value', function (done) {
         var obj = {
-          extname: '.md'
+          extname: '.md',
         };
         var expectedPath = 'test/fixtures/hello.md';
         helper(srcPattern, obj, expectedPath, done);
       });
-      it('removes extname with empty string', function(done) {
+      it('removes extname with empty string', function (done) {
         var obj = {
-          extname: ''
+          extname: '',
         };
         var expectedPath = 'test/fixtures/hello';
         helper(srcPattern, obj, expectedPath, done);
@@ -120,14 +121,14 @@ describe('gulp-rename', function() {
     });
   });
 
-  context('with function parameter', function() {
+  context('with function parameter', function () {
     var srcPattern;
-    beforeEach(function() {
+    beforeEach(function () {
       srcPattern = 'test/**/hello.txt';
     });
 
-    it('receives object with dirname', function(done) {
-      var obj = function(path) {
+    it('receives object with dirname', function (done) {
+      var obj = function (path) {
         path.dirname.should.equal('fixtures');
         path.dirname = 'elsewhere';
       };
@@ -135,8 +136,8 @@ describe('gulp-rename', function() {
       helper(srcPattern, obj, expectedPath, done);
     });
 
-    it('receives object with basename', function(done) {
-      var obj = function(path) {
+    it('receives object with basename', function (done) {
+      var obj = function (path) {
         path.basename.should.equal('hello');
         path.basename = 'aloha';
       };
@@ -144,8 +145,8 @@ describe('gulp-rename', function() {
       helper(srcPattern, obj, expectedPath, done);
     });
 
-    it('receives object with extname', function(done) {
-      var obj = function(path) {
+    it('receives object with extname', function (done) {
+      var obj = function (path) {
         path.extname.should.equal('.txt');
         path.extname = '.md';
       };
@@ -153,20 +154,20 @@ describe('gulp-rename', function() {
       helper(srcPattern, obj, expectedPath, done);
     });
 
-    it('receives object from return value', function(done) {
-      var obj = function(path) {
+    it('receives object from return value', function (done) {
+      var obj = function (path) {
         return {
           dirname: path.dirname,
           basename: path.basename,
-          extname: '.md'
+          extname: '.md',
         };
       };
       var expectedPath = 'test/fixtures/hello.md';
       helper(srcPattern, obj, expectedPath, done);
     });
 
-    it('ignores null return value but uses passed object', function(done) {
-      var obj = function(path) {
+    it('ignores null return value but uses passed object', function (done) {
+      var obj = function (path) {
         path.extname.should.equal('.txt');
         path.extname = '.md';
         return null;
@@ -175,8 +176,8 @@ describe('gulp-rename', function() {
       helper(srcPattern, obj, expectedPath, done);
     });
 
-    it('receives object with extname even if a different value is returned', function(done) {
-      var obj = function(path) {
+    it('receives object with extname even if a different value is returned', function (done) {
+      var obj = function (path) {
         path.extname.should.equal('.txt');
         path.extname = '.md';
       };
@@ -185,12 +186,13 @@ describe('gulp-rename', function() {
     });
   });
 
-  context('in parallel streams', function() {
-    it('only changes the file in the current stream', function(done) {
-      var files = gulp.src('test/fixtures/hello.txt');
+  context('in parallel streams', function () {
+    it('only changes the file in the current stream', function (done) {
+      // var files = gulp.src('test/fixtures/hello.txt');
 
-      var pipe1 = files.pipe(rename({ suffix: '-1' }));
-      var pipe2 = files.pipe(rename({ suffix: '-2' }));
+      var [files1, files2] = teex(gulp.src('test/fixtures/hello.txt'));
+      var pipe1 = files1.pipe(rename({ suffix: '-1' }));
+      var pipe2 = files2.pipe(rename({ suffix: '-2' }));
       var end1 = false;
       var end2 = false;
       var file1;
@@ -204,10 +206,10 @@ describe('gulp-rename', function() {
       }
 
       pipe1
-        .on('data', function(file) {
+        .on('data', function (file) {
           file1 = file;
         })
-        .on('end', function() {
+        .on('end', function () {
           end1 = true;
 
           if (end2) {
@@ -216,10 +218,10 @@ describe('gulp-rename', function() {
         });
 
       pipe2
-        .on('data', function(file) {
+        .on('data', function (file) {
           file2 = file;
         })
-        .on('end', function() {
+        .on('end', function () {
           end2 = true;
 
           if (end1) {
@@ -229,38 +231,38 @@ describe('gulp-rename', function() {
     });
   });
 
-  context('throws unsupported parameter type', function() {
+  context('throws unsupported parameter type', function () {
     var srcPattern;
-    beforeEach(function() {
+    beforeEach(function () {
       srcPattern = 'test/**/hello.txt';
     });
 
     var UNSUPPORTED_PARAMATER = 'Unsupported renaming parameter type supplied';
-    it('with undefined object', function(done) {
+    it('with undefined object', function (done) {
       var obj;
       var expectedError = UNSUPPORTED_PARAMATER;
       helperError(srcPattern, obj, expectedError, done);
     });
 
-    it('with null object', function(done) {
+    it('with null object', function (done) {
       var obj = null;
       var expectedError = UNSUPPORTED_PARAMATER;
       helperError(srcPattern, obj, expectedError, done);
     });
 
-    it('with empty string', function(done) {
+    it('with empty string', function (done) {
       var obj = '';
       var expectedError = UNSUPPORTED_PARAMATER;
       helperError(srcPattern, obj, expectedError, done);
     });
 
-    it('with boolean value', function(done) {
+    it('with boolean value', function (done) {
       var obj = true;
       var expectedError = UNSUPPORTED_PARAMATER;
       helperError(srcPattern, obj, expectedError, done);
     });
 
-    it('with numeric value', function(done) {
+    it('with numeric value', function (done) {
       var obj = 1;
       var expectedError = UNSUPPORTED_PARAMATER;
       helperError(srcPattern, obj, expectedError, done);

--- a/test/spec-helper.js
+++ b/test/spec-helper.js
@@ -7,34 +7,34 @@ var Path = require('path'),
   gulp = require('gulp'),
   rename = require('../');
 
-global.helper = function(srcArgs, obj, expectedPath, done, options) {
+global.helper = function (srcArgs, obj, expectedPath, done, options) {
   var srcPattern = srcArgs.pattern || srcArgs;
   var srcOptions = srcArgs.options || {};
   var stream = gulp.src(srcPattern, srcOptions).pipe(rename(obj, options));
   var count = 0;
   stream.on('error', done);
-  stream.on('data', function() {
+  stream.on('data', function () {
     count++;
   });
   if (expectedPath) {
-    stream.on('data', function(file) {
+    stream.on('data', function (file) {
       var resolvedExpectedPath = Path.resolve(expectedPath);
       var resolvedActualPath = Path.join(file.base, file.relative);
       resolvedActualPath.should.equal(resolvedExpectedPath);
     });
   }
-  stream.on('end', function() {
+  stream.on('end', function () {
     count.should.be.greaterThan(0);
     done.apply(this, arguments);
   });
 };
 
-global.helperError = function(srcPattern, obj, expectedError, done) {
+global.helperError = function (srcPattern, obj, expectedError, done) {
   var stream = gulp.src(srcPattern).pipe(rename(obj));
-  stream.on('error', function(err) {
+  stream.on('error', function (err) {
     err.message.should.equal(expectedError);
     done();
   });
-  stream.on('data', function() {});
+  stream.on('data', function () {});
   stream.on('end', done);
 };


### PR DESCRIPTION
Updated packages to get rid of this deprecation warning from vinyl-fs.
```
(node:66443) [DEP0180] DeprecationWarning: fs.Stats constructor is deprecated.
(Use `node --trace-deprecation ...` to show where the warning was created)
```
